### PR TITLE
chore(Typescript migration): Sketch workflows for github

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,20 @@
+name: Splittermond CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - devV*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Manual Build and Zip
+#Untested because we don't have github actions right now.
+on:
+  workflow_dispatch:
+    inputs:
+      outputName:
+        description: 'Version'
+        required: true
+
+jobs:
+  build-and-zip:
+    runs-on: ubuntu-latest
+    env:
+      outputName: splittermond-${github.event.inputs.Version}
+      outputFile: ${outputName}.zip
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Create zip
+        run: zip -r  ${outputFile} dist README.md screenshots
+      - name: Upload to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${outputName}
+          path: ${outputFile}


### PR DESCRIPTION
I generetad two workflows which should come in handy for this repo, once its public. 
They're AI generatted and untested, but I'm familiar with workflows, they look fine to me and they are super simple.

We should maybe wait until the repo is public though.

Possible improvemetns for the release flow:
*create release in gtihub
* tag in repo (maybe happens automatically with release)
