### PR TITLE
Allow github-actions bot to push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release new Splittermond version
 permissions:
   contents: write
+  id-token: write
   packages: write
 
 on:


### PR DESCRIPTION
There is little value in having the main branch not get the commit that was just released