### PR TITLE
fix(Attacks): NPC attacks now show up in attack tab again

### DIFF
--- a/src/module/item/attackable-item.ts
+++ b/src/module/item/attackable-item.ts
@@ -20,9 +20,8 @@ function AttackableItem<TBase extends Constructor<SplittermondItem>>(Base: TBase
         prepareActorData(): void {
             super.prepareActorData();
 
-            if(!("equipped" in this.system)) {
-               return
-            }else if (!this.system.equipped && this.type !== "npcattack") {
+            const isUnequipped = !("equipped" in this.system  && this.system.equipped);
+            if ( isUnequipped && this.type !== "npcattack") {
                 return;
             }
 


### PR DESCRIPTION
During migration we misread a check and accidentially ignored all unequipped or unequippable Items.