### PR TITLE
fix(Spell-migration): correct name for fumble action

### DIFF
--- a/public/templates/chat/spell-chat-card.hbs
+++ b/public/templates/chat/spell-chat-card.hbs
@@ -54,8 +54,8 @@
             {{#if useSplinterpoint}}
                 {{> "useSplinterpointButton" useSplinterpoint}}
             {{/if}}
-            {{#if rollFumble}}
-                {{> "rollFumbleButton" rollFumble}}
+            {{#if rollMagicFumble}}
+                {{> "rollFumbleButton" rollMagicFumble}}
             {{/if}}
         {{/with}}
 


### PR DESCRIPTION
Name differed from the one stated in interface