### PR TITLE
fix(NPCAttack): remove in-place merging.

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -6,7 +6,8 @@ export default class SplittermondItem extends Item {
         if (context?.splittermond?.ready) {
             super(data, context);
         } else {
-            foundryApi.mergeObject(context, { splittermond: { ready: true } },{inplace:true});
+            //In my opinion, this line shouldn't do anything, However, I don't have the time to test.
+            foundryApi.mergeObject(context, { splittermond: { ready: true } });
             const ItemConstructor = CONFIG.splittermond.Item.documentClasses[data.type];
             return ItemConstructor ? new ItemConstructor(data, context) : new SplittermondItem(data, context);
         }


### PR DESCRIPTION
Somehow, by actually altering the context we produced an edge case where the NPC Attack (and apparently only that one) would not be instantiated correctly on some browsers (firefox, foundry browser). I removed the in-place attribute but suspect that now the statement is entirely pointless, as we don't process the return value. However I lack the time to test this and therefor leave this code here.