### PR TITLE
Fix spell cast duration on actor drop

### DIFF
--- a/src/__tests__/unit/module/actor/sheets/actor-sheet.test.ts
+++ b/src/__tests__/unit/module/actor/sheets/actor-sheet.test.ts
@@ -69,6 +69,42 @@ describe("SplittermondActorSheet", () => {
             expect(superFunctionStub.lastCall.lastArg.system.skillLevel).to.equal(2);
         });
 
+        it("should preserve cast duration while setting spell skill", async () => {
+            const itemData: any = {
+                type: "spell",
+                system: new SpellDataModel({
+                    availableIn: "illusionmagic 2",
+                    skill: "arcanelore",
+                    skillLevel: 0,
+                    castDuration: { value: 12, unit: "T" },
+                } as any),
+            };
+            itemData.updateSource = (data: any) => {
+                itemData.system.skill = data["system.skill"];
+                itemData.system.skillLevel = data["system.skillLevel"];
+                itemData.system.castDuration = { value: 1, unit: "T" };
+            };
+            itemData.clone = (data: any) => {
+                const copy: any = {
+                    type: itemData.type,
+                    system: new SpellDataModel(itemData.system.toObject() as any),
+                };
+                copy.system.skill = data["system.skill"];
+                copy.system.skillLevel = data["system.skillLevel"];
+                return copy;
+            };
+
+            await sheet._onDropDocument(mockEvent, itemData);
+
+            expect(superFunctionStub.called).to.be.true;
+            expect(superFunctionStub.lastCall.lastArg.system.skill).to.equal("illusionmagic");
+            expect(superFunctionStub.lastCall.lastArg.system.skillLevel).to.equal(2);
+            expect(superFunctionStub.lastCall.lastArg.system.castDuration).to.deep.equal({ value: 12, unit: "T" });
+            expect(itemData.system.skill).to.equal("arcanelore");
+            expect(itemData.system.skillLevel).to.equal(0);
+            expect(itemData.system.castDuration).to.deep.equal({ value: 12, unit: "T" });
+        });
+
         it("should select only valid skill and skillLevel ", async () => {
             const itemData: any = {
                 type: "spell",

--- a/src/module/actor/sheets/actor-sheet.js
+++ b/src/module/actor/sheets/actor-sheet.js
@@ -669,7 +669,10 @@ export default class SplittermondActorSheet extends SplittermondBaseActorSheet {
 
             if (!selectedSkill) return;
 
-            document.system.updateSource({ skill: selectedSkill.skill, skillLevel: selectedSkill.level });
+            document = cloneDocumentWithSourceChanges(document, {
+                "system.skill": selectedSkill.skill,
+                "system.skillLevel": selectedSkill.level,
+            });
         }
         if (document.type === "mastery") {
             const allowedSkills = splittermond.skillGroups.all;
@@ -704,6 +707,26 @@ export default class SplittermondActorSheet extends SplittermondBaseActorSheet {
     _hasValidItemType(itemType) {
         return true;
     }
+}
+
+function cloneDocumentWithSourceChanges(document, changes) {
+    if (typeof document.clone === "function") return document.clone(changes);
+
+    const copy = {
+        ...document,
+        system: typeof document.system?.toObject === "function" ? document.system.toObject() : { ...document.system },
+    };
+
+    for (const [path, value] of Object.entries(changes)) {
+        const parts = path.split(".");
+        const key = parts.pop();
+        const target = parts.reduce((obj, part) => {
+            if (!obj[part]) obj[part] = {};
+            return obj[part];
+        }, copy);
+        target[key] = value;
+    }
+    return copy;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes spell drops from compendia so selecting a magic skill does not mutate the source compendium item and does not reset `castDuration` to the default `1 T`.

## Details

The actor sheet previously updated the dropped spell document directly while assigning `system.skill` and `system.skillLevel`. For compendium drops this can mutate the source document/cache and cause the embedded spell data to reinitialize `castDuration`.

This change clones the dropped spell document with the selected skill data and passes the clone to Foundry's normal drop handling.

## Verification

- `npm.cmd run format:check`
- `npm.cmd run test`
- `npm.cmd run ci-build`
- Manual Foundry test: dragging spells from the compendium preserves their configured cast duration.

Note:
This change was created with assistance from OpenAI Codex. I reviewed and tested the resulting changes locally.